### PR TITLE
Not enough party?

### DIFF
--- a/spec/aint_no_party_like_a_tdd_party_spec.rb
+++ b/spec/aint_no_party_like_a_tdd_party_spec.rb
@@ -20,7 +20,7 @@ describe "The never ending story" do
     num_gifs = text.scan(/\.gif/).count
     words_to_awesomeness_ratio = num_words / num_gifs
 
-    expect(words_to_awesomeness_ratio).to be >= 50
+    expect(words_to_awesomeness_ratio).to be <= 50
   end
 
   it "has animals" do


### PR DESCRIPTION
words_to_awesomeness_ratio was set to >= 50, which is more than 50 words per gif. I thought it would be better to have less words and more gifs, so I switched it to <=50
